### PR TITLE
fix: disallow xlink:href

### DIFF
--- a/src/DOMSanitizer.php
+++ b/src/DOMSanitizer.php
@@ -115,9 +115,15 @@ class DOMSanitizer
                 for($j = $element->attributes->length; --$j >= 0;) {
                     $attr_name = $element->attributes->item($j)->name;
                     $attr_value = $element->attributes->item($j)->textContent;
-                    if((!in_array(strtolower($attr_name), $attributes) && !$this->isSpecialCase($attr_name)) ||
+                    $attr_prefix = $element->attributes->item($j)->prefix;
+                    $attr_name_prefix = $attr_name;
+                    if ($attr_prefix !== '') {
+                        $attr_name_prefix = "$attr_prefix:$attr_name";
+                    }
+                    if ((!in_array(strtolower($attr_name_prefix), $attributes) && !$this->isSpecialCase($attr_name)) ||
                         $this->isExternalUrl($attr_value)) {
-                        $element->removeAttribute($attr_name);
+                        $attr_ns = $element->attributes->item($j)->namespaceURI;
+                        $element->removeAttributeNS($attr_ns, $attr_name);
                     }
                 }
             } else {

--- a/tests/DomSanitizerTest.php
+++ b/tests/DomSanitizerTest.php
@@ -164,6 +164,22 @@ final class DomSanitizerTest extends TestCase
         );
     }
 
+    public function testXlinkHRef(): void {
+        $bad_svg = file_get_contents(__DIR__ . '/xlink.svg');
+        $good_svg = file_get_contents(__DIR__ . '/xlink_expected.svg');
+        $sanitizer = new DOMSanitizer(DOMSanitizer::SVG);
+        $sanitizer->addDisallowedAttributes(['xlink:href']);
+
+        $output = $sanitizer->sanitize($bad_svg,  [
+            'compress-output' => false
+        ]);
+
+        $this->assertEqualHtml(
+            $good_svg,
+            $output
+        );
+    }
+
     protected function assertEqualHtml($expected, $actual)
     {
         $from = ['/\>[^\S ]+/s', '/[^\S ]+\</s', '/(\s)+/s', '/> </s'];

--- a/tests/xlink.svg
+++ b/tests/xlink.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <a xlink:href="https://developer.mozilla.org/">
+        <text x="10" y="25">MDN Web Docs</text>
+    </a>
+</svg>

--- a/tests/xlink_expected.svg
+++ b/tests/xlink_expected.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 160 40">
+    <a>
+        <text x="10" y="25">MDN Web Docs</text>
+    </a>
+</svg>


### PR DESCRIPTION
`xlink:href` was neither detected nor properly removed from the xml due to the namespace prefix.